### PR TITLE
update "timer pause on restart" feature

### DIFF
--- a/borderlands3.asl
+++ b/borderlands3.asl
@@ -135,6 +135,12 @@ onStart {
     vars.delayedSplitTime = TimeSpan.Zero;
     vars.lastGameWorld = null;
 
+    /*
+    If the game is restarted while the timer is not running, we set this value to false
+    to prevent the timer from being paused at 0.00 until the next load screen.
+    */
+    vars.gameRestart = false;
+
     vars.resetCounter();
 }
 


### PR DESCRIPTION
Fixed an issue where the timer would remain paused on start if the game was restarted while the timer was not running