### PR TITLE
disable timer fix on start if timer offset is applied (BL3)

### DIFF
--- a/borderlands3.asl
+++ b/borderlands3.asl
@@ -806,7 +806,8 @@ isLoading {
         || vars.currentWorld == "MenuMap_P"
     ) {
         // If you start on the main menu sometimes a single tick is counted before pausing, fix it
-        if (timer.CurrentAttemptDuration.TotalSeconds < 0.1) {
+        // If you have a start offset this fix is ignored
+        if (timer.CurrentAttemptDuration.TotalSeconds < 0.1 && timer.CurrentTime.GameTime < TimeSpan.FromSeconds(0.1)) {
             timer.SetGameTime(TimeSpan.Zero);
         }
 


### PR DESCRIPTION
Edited the timer fix for a bug that sometimes allows a tick of time to pass before pausing the timer if started from the main menu or a loadscreen to NOT apply when the user has a start offset